### PR TITLE
Add lab for basic IPv6 L3 forwarding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 ._*
 .DS_Store
 *.log
+*~

--- a/00-unit-labs/0000-topology/README.md
+++ b/00-unit-labs/0000-topology/README.md
@@ -23,17 +23,23 @@ The role of each components are:
 * `core1-eth1` - `p4-core1-cpu2` are veth peers and are control plane link end points
 
 The addressing rules are:    
-* `router loopback IP` = 10.`pod_id`.`pod_id`.`pod_id` 
-* `router interconnect IP` = 10.0.`pod_id`.`pod_id`
+* `router loopback IPv4` = 10.`pod_id`.`pod_id`.`pod_id`/32
+* `router loopback IPv6` = FD00::`pod_id`/128
+* `router interconnect IPv4` = 10.0.`pod_id`.`pod_id`/24
+* `router interconnect IPv6` = FD00:0:0:`pod_id`::`pod_id`/64
 * `hw-mac` = 0000.`<0xIP>` 
 
 Example: 
 * `cpe1` `pod_id`=1 : 
-* `cpe1 loopback IP` = 10.1.1.1  
-* `cpe1 interconnect IP` = 10.0.1.1 
+* `cpe1 loopback IPv4` = 10.1.1.1/32
+* `cpe1 loopback IPv6` = FD00::1/128
+* `cpe1 interconnect IPv4` = 10.0.1.1/24
+* `cpe1 interconnect IPv6` = FD00:0:0:1::1/64
 * `cpe1-eth0 hw-mac` = 0000.0A00.0101 
 
-This setup is meant to minimise additional developement at FreeRTR control plane level in oredr to support a P4 dataplane.   
+FIXME: document IPv6 subnets and static routes
+
+This setup is meant to minimise additional developement at FreeRTR control plane level in order to support a P4 dataplane.
 
 # Run topology
 ```

--- a/00-unit-labs/0000-topology/run/core1/core1-sw.txt
+++ b/00-unit-labs/0000-topology/run/core1/core1-sw.txt
@@ -31,6 +31,7 @@ interface loopback0
  macaddr 0000.0afe.fefe
  vrf forwarding v1
  ipv4 address 10.254.254.254 255.255.255.255
+ ipv6 address fd00::fe ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
  router isis4 1 enable
  router isis4 1 passive
  router isis4 1 circuit level1
@@ -44,6 +45,7 @@ interface loopback1
  no description
  vrf forwarding v1
  ipv4 address 6.6.6.6 255.255.255.0
+ ipv6 address fd00:0:6:6::6 ffff:ffff:ffff:ffff::
  router isis4 1 enable
  router isis4 1 passive
  router isis4 1 circuit level1
@@ -57,6 +59,8 @@ interface ethernet0
  vrf forwarding v1
  ipv4 address 10.0.1.254 255.255.255.0
  ipv4 host-static 10.0.1.1 0000.0a00.0101
+ ipv6 address fd00:0:0:1::fe ffff:ffff:ffff:ffff::
+ ipv6 host-static fd00:0:0:1::1 0000.0a00.0101
  mpls enable
  router isis4 1 enable
  router isis4 1 circuit level1
@@ -70,6 +74,8 @@ interface ethernet1
  vrf forwarding v1
  ipv4 address 10.0.2.254 255.255.255.0
  ipv4 host-static 10.0.2.2 0000.0a00.0202
+ ipv6 address fd00:0:0:2::fe ffff:ffff:ffff:ffff::
+ ipv6 host-static fd00:0:0:2::2 0000.0a00.0202
  mpls enable
  router isis4 1 enable
  router isis4 1 circuit level1
@@ -92,6 +98,10 @@ interface ethernet1
 !
 !
 !
+ipv6 route v1 fd00::1 ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff fd00:0:0:1::1
+ipv6 route v1 fd00::2 ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff fd00:0:0:2::2
+ipv6 route v1 fd00:0:1:1:: ffff:ffff:ffff:ffff:: fd00:0:0:1::1
+ipv6 route v1 fd00:0:2:2:: ffff:ffff:ffff:ffff:: fd00:0:0:2::2
 !
 !
 !

--- a/00-unit-labs/0000-topology/run/cpe1/cpe1-sw.txt
+++ b/00-unit-labs/0000-topology/run/cpe1/cpe1-sw.txt
@@ -31,6 +31,7 @@ interface loopback0
  macaddr 0000.0a01.0101
  vrf forwarding v1
  ipv4 address 10.1.1.1 255.255.255.255
+ ipv6 address fd00::1 ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
  router isis4 1 enable
  router isis4 1 passive
  router isis4 1 circuit level1
@@ -44,6 +45,7 @@ interface loopback1
  no description
  vrf forwarding v1
  ipv4 address 1.1.1.1 255.255.255.0
+ ipv6 address fd00:0:1:1::1 ffff:ffff:ffff:ffff::
  router isis4 1 enable
  router isis4 1 passive
  router isis4 1 circuit level1
@@ -65,6 +67,8 @@ interface ethernet0
  vrf forwarding v1
  ipv4 address 10.0.1.1 255.255.255.0
  ipv4 host-static 10.0.1.254 0000.0a00.01fe
+ ipv6 address fd00:0:0:1::1 ffff:ffff:ffff:ffff::
+ ipv6 host-static fd00:0:0:1::fe 0000.0a00.01fe
  mpls enable
  router isis4 1 enable
  router isis4 1 circuit level1
@@ -103,6 +107,11 @@ router bgp4 1
 !
 !
 !
+ipv6 route v1 fd00::fe ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff fd00:0:0:1::fe
+ipv6 route v1 fd00::2 ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff fd00:0:0:1::fe
+ipv6 route v1 fd00:0:0:2:: ffff:ffff:ffff:ffff:: fd00:0:0:1::fe
+ipv6 route v1 fd00:0:2:2:: ffff:ffff:ffff:ffff:: fd00:0:0:1::fe
+ipv6 route v1 fd00:0:6:6:: ffff:ffff:ffff:ffff:: fd00:0:0:1::fe
 !
 !
 !

--- a/00-unit-labs/0000-topology/run/cpe2/cpe2-sw.txt
+++ b/00-unit-labs/0000-topology/run/cpe2/cpe2-sw.txt
@@ -31,6 +31,7 @@ interface loopback0
  macaddr 0000.0a02.0202
  vrf forwarding v1
  ipv4 address 10.2.2.2 255.255.255.0
+ ipv6 address fd00::2 ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff
  router isis4 1 enable
  router isis4 1 circuit level1
  router isis4 1 segrout index 3
@@ -43,6 +44,7 @@ interface loopback1
  no description
  vrf forwarding v1
  ipv4 address 2.2.2.2 255.255.255.0
+ ipv6 address fd00:0:2:2::2 ffff:ffff:ffff:ffff::
  router isis4 1 enable
  router isis4 1 passive
  router isis4 1 circuit level1
@@ -64,6 +66,8 @@ interface ethernet0
  vrf forwarding v1
  ipv4 address 10.0.2.2 255.255.255.0
  ipv4 host-static 10.0.2.254 0000.0a00.02fe
+ ipv6 address fd00:0:0:2::2 ffff:ffff:ffff:ffff::
+ ipv6 host-static fd00:0:0:2::fe 0000.0a00.02fe
  mpls enable
  router isis4 1 enable
  router isis4 1 circuit level1
@@ -102,6 +106,11 @@ router bgp4 1
 !
 !
 !
+ipv6 route v1 fd00::fe ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff fd00:0:0:2::fe
+ipv6 route v1 fd00::1 ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff fd00:0:0:2::fe
+ipv6 route v1 fd00:0:0:1:: ffff:ffff:ffff:ffff:: fd00:0:0:2::fe
+ipv6 route v1 fd00:0:1:1:: ffff:ffff:ffff:ffff:: fd00:0:0:2::fe
+ipv6 route v1 fd00:0:6:6:: ffff:ffff:ffff:ffff:: fd00:0:0:2::fe
 !
 !
 !

--- a/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/Makefile
+++ b/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/Makefile
@@ -5,6 +5,7 @@ LOG_DIR = $(RUN_DIR)/log
 LOG_FILE = p4-core1
 P4C = p4c
 BMV2_SWITCH_EXE = simple_switch
+BMV2_SWITCH_CLI = $(BMV2_SWITCH_EXE)_CLI
 
 source := $(wildcard *.p4)
 json_outfile := $(source:.p4=.json)
@@ -37,3 +38,5 @@ clean:
 dirs:
 	mkdir -p $(BUILD_DIR) $(LOG_DIR)
 
+tables: tables.in
+	$(BMV2_SWITCH_CLI) --thrift-port 9090 <$?

--- a/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/Makefile
+++ b/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/Makefile
@@ -1,0 +1,39 @@
+include ./Makefile.local
+BUILD_DIR = ../build
+RUN_DIR = ../run
+LOG_DIR = $(RUN_DIR)/log
+LOG_FILE = p4-core1
+P4C = p4c
+BMV2_SWITCH_EXE = simple_switch
+
+source := $(wildcard *.p4)
+json_outfile := $(source:.p4=.json)
+p4info_outfile := $(source:.p4=.txt)
+
+compiled_json := $(BUILD_DIR)/$(json_outfile)
+compiled_p4info := $(BUILD_DIR)/$(p4info_outfile)
+
+# Set BMV2_SWITCH_EXE to override the BMv2 target
+#ifdef BMV2_SWITCH_EXE
+#   run_args += -b $(BMV2_SWITCH_EXE)
+#endif
+
+all: run
+
+run: build
+	sudo $(BMV2_SWITCH_EXE)  --log-file $(LOG_DIR)/$(LOG_FILE) \
+			-i 1@p4-core1-dp1 -i 2@p4-core1-dp2 \
+			-i 255@p4-core1-cpu1 -i 254@p4-core1-cpu2 \
+			--thrift-port 9090 --nanolog ipc://$(RUN_DIR)/bm-0-log.ipc --device-id 0 $(compiled_json) > $(LOG_DIR)/$(LOG_FILE).out 2>&1 &
+
+build: dirs 
+	$(P4C) --std p4-16 --target bmv2 --arch v1model \
+		-I ./ -o $(BUILD_DIR) --p4runtime-files $(compiled_p4info) $(P4_PROGRAM) 
+
+clean: 
+	-sudo killall simple_switch
+	-rm -rf $(BUILD_DIR) $(LOG_DIR) $(RUN_DIR)
+
+dirs:
+	mkdir -p $(BUILD_DIR) $(LOG_DIR)
+

--- a/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/Makefile.local
+++ b/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/Makefile.local
@@ -1,0 +1,3 @@
+## Set to the name of the test-specific p4 program, e.g.
+## P4_PROGRAM = optimized-ipv4-forwarding.p4
+P4_PROGRAM = unoptimized-ipv6-forwarding.p4

--- a/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/README.md
+++ b/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/README.md
@@ -1,0 +1,128 @@
+# Lab topology
+The topology used is common to all unit labs defined [here](https://github.com/frederic-loui/RARE/tree/master/00-unit-labs/0000-topology).
+# Lab title
+**Unoptimized IPv6 forwarding**
+# Lab objective
+This lab demonstrates basic IPv6 forwarding.
+* The `parser` matches only `ipv6` packets.
+* Subsequently the `ingress` control applies one **IPv6 host** table that perform `exact` match against host(`/128`) routes. This table contains
+addresses that belong to the router itself (_local_ addresses) and addresses in directly attached networks for which address resolution has been
+performed by the control-plane.
+* and if theres is no match apply a **IPv6 network** table that performs `lpm` match operation againt network(`/cidr`) routes.
+
+# Lab operation
+* Run the reference Lab architecture defined [here](https://github.com/frederic-loui/RARE/tree/master/00-unit-labs/0000-topology).
+* Compile `unoptimized-ipv6-forwarding.p4` and launch `simple_switch`
+```
+cd ~/RARE/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src
+make
+```
+
+# Control Plane operation
+* connect to `core1` and display the IPv6 routing table for VRF `v1`
+```
+$ sudo ip netns exec core1 telnet 127.0.0.1 2323
+Trying 127.0.0.1...
+Connected to 127.0.0.1.
+Escape character is '^]'.
+welcome
+line ready
+core1#show ipv6 route v1                                                                                                          
+typ  prefix              metric  iface      hop            time
+S    fd00::1/128         1/0     ethernet0  fd00:0:0:1::1  01:11:28
+S    fd00::2/128         1/0     ethernet1  fd00:0:0:2::2  01:11:28
+C    fd00::fe/128        0/0     loopback0  null           01:11:28
+C    fd00:0:0:1::/64     0/0     ethernet0  null           01:11:28
+LOC  fd00:0:0:1::fe/128  0/1     ethernet0  null           01:11:28
+C    fd00:0:0:2::/64     0/0     ethernet1  null           01:11:28
+LOC  fd00:0:0:2::fe/128  0/1     ethernet1  null           01:11:28
+S    fd00:0:1:1::/64     1/0     ethernet0  fd00:0:0:1::1  01:11:28
+S    fd00:0:2:2::/64     1/0     ethernet1  fd00:0:0:2::2  01:11:28
+C    fd00:0:6:6::/64     0/0     loopback1  null           01:11:28
+LOC  fd00:0:6:6::6/128   0/1     loopback1  null           01:11:28
+
+core1# 
+```
+* Connect `p4-core1` via CLI:
+```
+simple_switch_CLI --thrift-port 9090
+Obtaining JSON from switch...
+Done
+Control utility for runtime P4 table manipulation
+RuntimeCmd:
+```
+* Insert the FIB entries from `core1` into the proper tables of the data-plane
+```
+# S    fd00::1/128         1/0     ethernet0  fd00:0:0:1::1
+table_add ctl_ingress.l3.tbl_ipv6_fib_lpm ctl_ingress.l3.act_ipv6_fib_forward fd00::1/128 => 00:00:0a:00:01:fe 00:00:0a:00:01:01 1
+# S    fd00::2/128         1/0     ethernet1  fd00:0:0:2::2
+table_add ctl_ingress.l3.tbl_ipv6_fib_lpm ctl_ingress.l3.act_ipv6_fib_forward fd00::2/128 => 00:00:0a:00:02:fe 00:00:0a:00:02:02 2
+# C    fd00::fe/128        0/0     loopback0  null
+table_add ctl_ingress.l3.tbl_ipv6_fib_host ctl_ingress.l3.act_ipv6_fib_local fd00::fe => 255
+# C    fd00:0:0:1::/64     0/0     ethernet0  null
+table_add ctl_ingress.l3.tbl_ipv6_fib_lpm ctl_ingress.l3.act_ipv6_fib_glean fd00:0:0:1::/64
+# LOC  fd00:0:0:1::fe/128  0/1     ethernet0  null
+table_add ctl_ingress.l3.tbl_ipv6_fib_host ctl_ingress.l3.act_ipv6_fib_local fd00:0:0:1::fe => 255
+# C    fd00:0:0:2::/64     0/0     ethernet1  null
+table_add ctl_ingress.l3.tbl_ipv6_fib_lpm ctl_ingress.l3.act_ipv6_fib_glean fd00:0:0:2::/64 =>
+# LOC  fd00:0:0:2::fe/128  0/1     ethernet1  null
+table_add ctl_ingress.l3.tbl_ipv6_fib_host ctl_ingress.l3.act_ipv6_fib_local fd00:0:0:2::fe => 254
+# S    fd00:0:1:1::/64     1/0     ethernet0  fd00:0:0:1::1
+table_add ctl_ingress.l3.tbl_ipv6_fib_lpm ctl_ingress.l3.act_ipv6_fib_forward fd00:0:1:1::/64 => 00:00:0a:00:01:fe 00:00:0a:00:01:01 1
+# S    fd00:0:2:2::/64     1/0     ethernet1  fd00:0:0:2::2
+table_add ctl_ingress.l3.tbl_ipv6_fib_lpm ctl_ingress.l3.act_ipv6_fib_forward fd00:0:2:2::/64 => 00:00:0a:00:02:fe 00:00:0a:00:02:02 2
+# C    fd00:0:6:6::/64     0/0     loopback1  null
+table_add ctl_ingress.l3.tbl_ipv6_fib_lpm ctl_ingress.l3.act_ipv6_fib_glean fd00:0:6:6::/64  =>
+# LOC  fd00:0:6:6::6/128   0/1     loopback1  null
+table_add ctl_ingress.l3.tbl_ipv6_fib_host ctl_ingress.l3.act_ipv6_fib_local fd00:0:6:6::6 => 255
+# Neighbor entry for fd00:0:0:1::1
+table_add ctl_ingress.l3.tbl_ipv6_fib_host ctl_ingress.l3.act_ipv6_fib_forward fd00:0:0:1::1 => 00:00:0a:00:01:fe 00:00:0a:00:01:01 1
+# Neighbor entry for fd00:0:0:2::2
+table_add ctl_ingress.l3.tbl_ipv6_fib_host ctl_ingress.l3.act_ipv6_fib_forward fd00:0:0:2::2 => 00:00:0a:00:02:fe 00:00:0a:00:02:02 2
+```
+
+# Lab verification
+* On `cpe1`:
+```
+$ sudo ip netns exec cpe1 telnet 127.0.0.1 2323
+Trying 127.0.0.1...
+Connected to 127.0.0.1.
+Escape character is '^]'.
+welcome
+line ready
+cpe1#ping fd00::2 /vrf v1                                                                                                         
+pinging fd00::2, src=null, cnt=5, len=64, tim=1000, ttl=255, tos=0, sweep=false
+!!!!!
+result=100%, recv/sent/lost=5/5/0, rtt min/avg/max/total=2/2/3/16
+cpe1#ping fd00::fe /vrf v1                                                                                                        
+pinging fd00::fe, src=null, cnt=5, len=64, tim=1000, ttl=255, tos=0, sweep=false
+!!!!!
+result=100%, recv/sent/lost=5/5/0, rtt min/avg/max/total=2/2/3/15
+cpe1#ping fd00:0:0:1::fe /vrf v1                                                                                                  
+pinging fd00:0:0:1::fe, src=null, cnt=5, len=64, tim=1000, ttl=255, tos=0, sweep=false
+!!!!!
+result=100%, recv/sent/lost=5/5/0, rtt min/avg/max/total=2/2/3/13
+cpe1#ping fd00:0:0:2::fe /vrf v1                                                                                                  
+pinging fd00:0:0:2::fe, src=null, cnt=5, len=64, tim=1000, ttl=255, tos=0, sweep=false
+!!!!!
+result=100%, recv/sent/lost=5/5/0, rtt min/avg/max/total=1/2/3/10
+cpe1#ping fd00:0:2:2::2 /vrf v1                                                                                                   
+pinging fd00:0:2:2::2, src=null, cnt=5, len=64, tim=1000, ttl=255, tos=0, sweep=false
+!!!!!
+result=100%, recv/sent/lost=5/5/0, rtt min/avg/max/total=2/3/4/16
+cpe1#ping fd00:0:0:2::2 /vrf v1                                                                                                   
+pinging fd00:0:0:2::2, src=null, cnt=5, len=64, tim=1000, ttl=255, tos=0, sweep=false
+!!!!!
+result=100%, recv/sent/lost=5/5/0, rtt min/avg/max/total=2/2/3/15
+cpe1#ping fd00:0:6:6::6 /vrf v1                                                                                                   
+pinging fd00:0:6:6::6, src=null, cnt=5, len=64, tim=1000, ttl=255, tos=0, sweep=false
+!!!!!
+result=100%, recv/sent/lost=5/5/0, rtt min/avg/max/total=2/2/3/14
+```
+# Key take-away
+* This program handles all types of forwarding, i.e. local addresses, directly connected networks and routed networks
+* The tables have been designed such that the router's FIB entries can be programmed in a natural manner
+* All static routes and IPv6 neighbors are part of the base topology
+```
+# Follow-ups
+* A subsequent lab will introduce indirection for the next-hop of routed networks to reduce the size of tables and make to make updates to a particular next-hop more efficient

--- a/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/README.md
+++ b/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/README.md
@@ -123,6 +123,5 @@ result=100%, recv/sent/lost=5/5/0, rtt min/avg/max/total=2/2/3/14
 * This program handles all types of forwarding, i.e. local addresses, directly connected networks and routed networks
 * The tables have been designed such that the router's FIB entries can be programmed in a natural manner
 * All static routes and IPv6 neighbors are part of the base topology
-```
 # Follow-ups
 * A subsequent lab will introduce indirection for the next-hop of routed networks to reduce the size of tables and make to make updates to a particular next-hop more efficient

--- a/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/README.md
+++ b/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/README.md
@@ -19,6 +19,24 @@ make
 ```
 
 # Control Plane operation
+* P4 tables
+   * `tbl_ipv6_fib_host`
+      * Key: `<ipv6 address>`
+      * Action id: `act_ipv6_fib_local`
+        * Action params: {CPU port}
+        * Trigger: when the router adds an address that belongs to itself (either a route marked `LOCAL` or a route marked `CONNECTED` with a prefix length of 128)
+      * Action id: `act_ipv6_fib_forward`
+        * Action params: {source MAC address, destination MAC address, egress port}
+        * Trigger: when address resolution for a directly connected neighbor complets
+   * `tbl_ipv6_fib_lpm`
+      * Key: `<ipv6 prefix>`
+      * Action id: `act_ipv6_fib_forward`
+        * Action params: {source MAC address, destination MAC address, egress port}
+        * Trigger: when address resolution for the next-hop complets
+      * Action id: `act_ipv6_fib_glean`
+        * Action params: {TBD}
+        * Trigger: when a `CONNECTED` prefix is configured
+        
 * connect to `core1` and display the IPv6 routing table for VRF `v1`
 ```
 $ sudo ip netns exec core1 telnet 127.0.0.1 2323
@@ -43,42 +61,39 @@ LOC  fd00:0:6:6::6/128   0/1     loopback1  null           01:11:28
 
 core1# 
 ```
-* Connect `p4-core1` via CLI:
+* Check the programming of the p4 tables based on the routing table and (fictitious) ARP requests for directly connected systems
 ```
-simple_switch_CLI --thrift-port 9090
-Obtaining JSON from switch...
-Done
-Control utility for runtime P4 table manipulation
-RuntimeCmd:
-```
-* Insert the FIB entries from `core1` into the proper tables of the data-plane
-```
-# S    fd00::1/128         1/0     ethernet0  fd00:0:0:1::1
+$ cat tables.in 
+# S    fd00::1/128         1/0     ethernet0  fd00:0:0:1::1  01:11:28
 table_add ctl_ingress.l3.tbl_ipv6_fib_lpm ctl_ingress.l3.act_ipv6_fib_forward fd00::1/128 => 00:00:0a:00:01:fe 00:00:0a:00:01:01 1
-# S    fd00::2/128         1/0     ethernet1  fd00:0:0:2::2
+# S    fd00::2/128         1/0     ethernet1  fd00:0:0:2::2  01:11:28
 table_add ctl_ingress.l3.tbl_ipv6_fib_lpm ctl_ingress.l3.act_ipv6_fib_forward fd00::2/128 => 00:00:0a:00:02:fe 00:00:0a:00:02:02 2
-# C    fd00::fe/128        0/0     loopback0  null
+# C    fd00::fe/128        0/0     loopback0  null           01:11:28
 table_add ctl_ingress.l3.tbl_ipv6_fib_host ctl_ingress.l3.act_ipv6_fib_local fd00::fe => 255
-# C    fd00:0:0:1::/64     0/0     ethernet0  null
+# C    fd00:0:0:1::/64     0/0     ethernet0  null           01:11:28
 table_add ctl_ingress.l3.tbl_ipv6_fib_lpm ctl_ingress.l3.act_ipv6_fib_glean fd00:0:0:1::/64
-# LOC  fd00:0:0:1::fe/128  0/1     ethernet0  null
+# LOC  fd00:0:0:1::fe/128  0/1     ethernet0  null           01:11:28
 table_add ctl_ingress.l3.tbl_ipv6_fib_host ctl_ingress.l3.act_ipv6_fib_local fd00:0:0:1::fe => 255
-# C    fd00:0:0:2::/64     0/0     ethernet1  null
+# C    fd00:0:0:2::/64     0/0     ethernet1  null           01:11:28
 table_add ctl_ingress.l3.tbl_ipv6_fib_lpm ctl_ingress.l3.act_ipv6_fib_glean fd00:0:0:2::/64 =>
-# LOC  fd00:0:0:2::fe/128  0/1     ethernet1  null
+# LOC  fd00:0:0:2::fe/128  0/1     ethernet1  null           01:11:28
 table_add ctl_ingress.l3.tbl_ipv6_fib_host ctl_ingress.l3.act_ipv6_fib_local fd00:0:0:2::fe => 254
-# S    fd00:0:1:1::/64     1/0     ethernet0  fd00:0:0:1::1
+# S    fd00:0:1:1::/64     1/0     ethernet0  fd00:0:0:1::1  01:11:28
 table_add ctl_ingress.l3.tbl_ipv6_fib_lpm ctl_ingress.l3.act_ipv6_fib_forward fd00:0:1:1::/64 => 00:00:0a:00:01:fe 00:00:0a:00:01:01 1
-# S    fd00:0:2:2::/64     1/0     ethernet1  fd00:0:0:2::2
+# S    fd00:0:2:2::/64     1/0     ethernet1  fd00:0:0:2::2  01:11:28
 table_add ctl_ingress.l3.tbl_ipv6_fib_lpm ctl_ingress.l3.act_ipv6_fib_forward fd00:0:2:2::/64 => 00:00:0a:00:02:fe 00:00:0a:00:02:02 2
-# C    fd00:0:6:6::/64     0/0     loopback1  null
+# C    fd00:0:6:6::/64     0/0     loopback1  null           01:11:28
 table_add ctl_ingress.l3.tbl_ipv6_fib_lpm ctl_ingress.l3.act_ipv6_fib_glean fd00:0:6:6::/64  =>
-# LOC  fd00:0:6:6::6/128   0/1     loopback1  null
+# LOC  fd00:0:6:6::6/128   0/1     loopback1  null           01:11:28
 table_add ctl_ingress.l3.tbl_ipv6_fib_host ctl_ingress.l3.act_ipv6_fib_local fd00:0:6:6::6 => 255
 # Neighbor entry for fd00:0:0:1::1
 table_add ctl_ingress.l3.tbl_ipv6_fib_host ctl_ingress.l3.act_ipv6_fib_forward fd00:0:0:1::1 => 00:00:0a:00:01:fe 00:00:0a:00:01:01 1
 # Neighbor entry for fd00:0:0:2::2
 table_add ctl_ingress.l3.tbl_ipv6_fib_host ctl_ingress.l3.act_ipv6_fib_forward fd00:0:0:2::2 => 00:00:0a:00:02:fe 00:00:0a:00:02:02 2
+```
+* Program the tables
+```
+$ make tables
 ```
 
 # Lab verification

--- a/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/ethernet.p4
+++ b/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/ethernet.p4
@@ -2,6 +2,7 @@
 #define _ETHERNET_P4_
 
 #include <include/types.p4>
+
 /*
  * Ethernet header: as a header type, order matters
  */

--- a/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/ethernet.p4
+++ b/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/ethernet.p4
@@ -1,0 +1,13 @@
+/*
+ * HW MAC address encoded using 48 bits
+ */
+typedef bit<48> mac_addr_t;
+
+/*
+ * Ethernet header: as a header type, order matters
+ */
+header ethernet_t {
+   mac_addr_t dst_mac_addr;
+   mac_addr_t src_mac_addr;
+   bit<16>   ethertype;
+}

--- a/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/ethernet.p4
+++ b/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/ethernet.p4
@@ -1,8 +1,7 @@
-/*
- * HW MAC address encoded using 48 bits
- */
-typedef bit<48> mac_addr_t;
+#ifndef _ETHERNET_P4_
+#define _ETHERNET_P4_
 
+#include <include/types.p4>
 /*
  * Ethernet header: as a header type, order matters
  */
@@ -11,3 +10,5 @@ header ethernet_t {
    mac_addr_t src_mac_addr;
    bit<16>   ethertype;
 }
+
+#endif // _ETHERNET_P4_

--- a/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/ethertype.p4
+++ b/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/ethertype.p4
@@ -17,6 +17,9 @@
 // source here: 
 // https://www.iana.org/assignments/ieee-802-numbers/ieee-802-numbers.xhtml 
 
+#ifndef _ETHERTYPE_P4_
+#define _ETHERTYPE_P4_
+
 const bit<16> ETHERTYPE_IPV4              = 0x0800;
 const bit<16> ETHERTYPE_ARP               = 0x0806;
 const bit<16> ETHERTYPE_WOL               = 0x0842;
@@ -75,4 +78,4 @@ const bit<16> ETHERTYPE_ETHERNET_CTP      = 0x9000;
 const bit<16> ETHERTYPE_QINQ              = 0x9100;
 const bit<16> ETHERTYPE_VERITAS_LLT       = 0xCAFE;
 
-
+#endif // _ETHERTYPE_P4_

--- a/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/ethertype.p4
+++ b/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/ethertype.p4
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2019-present GÉANT RARE project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed On an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// source here: 
+// https://www.iana.org/assignments/ieee-802-numbers/ieee-802-numbers.xhtml 
+
+const bit<16> ETHERTYPE_IPV4              = 0x0800;
+const bit<16> ETHERTYPE_ARP               = 0x0806;
+const bit<16> ETHERTYPE_WOL               = 0x0842;
+const bit<16> ETHERTYPE_TRILL             = 0x22f3;
+const bit<16> ETHERTYPE_SRVP              = 0x22ea;
+const bit<16> ETHERTYPE_DECNET            = 0x6003;
+const bit<16> ETHERTYPE_ETHERNET          = 0x6558;
+const bit<16> ETHERTYPE_RARP              = 0x8035;
+const bit<16> ETHERTYPE_ETHERTALK         = 0x809b;
+const bit<16> ETHERTYPE_AARP              = 0x80f3;
+const bit<16> ETHERTYPE_VLAN              = 0x8100;
+const bit<16> ETHERTYPE_IPX               = 0x8137;
+const bit<16> ETHERTYPE_NOVELL            = 0x8138;
+const bit<16> ETHERTYPE_QNX_QNET          = 0x8204;
+const bit<16> ETHERTYPE_IPV6              = 0x86dd;
+const bit<16> ETHERTYPE_ETHERNET_FC       = 0x8808;
+const bit<16> ETHERTYPE_LACP              = 0x8809;
+const bit<16> ETHERTYPE_COBRANET          = 0x8819;
+const bit<16> ETHERTYPE_MPLS_UCAST        = 0x8847;
+const bit<16> ETHERTYPE_MPLS_MCAST        = 0x8848;
+const bit<16> ETHERTYPE_PPPOE_DISCOVERY   = 0x8863;
+const bit<16> ETHERTYPE_PPPOE_SESSION     = 0x8864;
+const bit<16> ETHERTYPE_INTEL_ADV_NET_SVC = 0x8864;
+const bit<16> ETHERTYPE_JUMBO_FRAMES      = 0x8870;
+const bit<16> ETHERTYPE_HOME_PLUG         = 0x887b;
+const bit<16> ETHERTYPE_EAPOLAN           = 0x888e;
+const bit<16> ETHERTYPE_PROFINET          = 0x8892;
+const bit<16> ETHERTYPE_ETHERSOUND        = 0x8896;
+const bit<16> ETHERTYPE_HYPERSCSI         = 0x889a;
+const bit<16> ETHERTYPE_ATAOETHERNET      = 0x88a2;
+const bit<16> ETHERTYPE_ETHERCAT          = 0x88a4;
+const bit<16> ETHERTYPE_PBB_SPB           = 0x88a8;
+const bit<16> ETHERTYPE_POWERLINK         = 0x88ab;
+const bit<16> ETHERTYPE_GOOSE             = 0x88b8;
+const bit<16> ETHERTYPE_GSE_MS            = 0x88b9;
+const bit<16> ETHERTYPE_SVT               = 0x88ba;
+const bit<16> ETHERTYPE_LLDP              = 0x88cc;
+const bit<16> ETHERTYPE_SERCOS            = 0x88cd;
+const bit<16> ETHERTYPE_WSMP              = 0x88dc;
+const bit<16> ETHERTYPE_HOMEPLUG_AV_MME   = 0x88e1;
+const bit<16> ETHERTYPE_MRP               = 0x88e3;
+const bit<16> ETHERTYPE_MAC_SEC           = 0x88e5;
+const bit<16> ETHERTYPE_PBB               = 0x88e7;
+const bit<16> ETHERTYPE_PTP               = 0x88f7;
+const bit<16> ETHERTYPE_NC_SI             = 0x88f8;
+const bit<16> ETHERTYPE_PRP               = 0x88fb;
+const bit<16> ETHERTYPE_CFM               = 0x8902;
+const bit<16> ETHERTYPE_FCOE              = 0x8906;
+const bit<16> ETHERTYPE_FCOE_INIT         = 0x8914;
+const bit<16> ETHERTYPE_ROCE              = 0x8915;
+const bit<16> ETHERTYPE_TTE               = 0x891d;
+const bit<16> ETHERTYPE_VNTAG             = 0x8926;
+const bit<16> ETHERTYPE_HSR               = 0x892f;
+const bit<16> ETHERTYPE_NSH               = 0x894f;
+const bit<16> ETHERTYPE_ETHERNET_CTP      = 0x9000;
+const bit<16> ETHERTYPE_QINQ              = 0x9100;
+const bit<16> ETHERTYPE_VERITAS_LLT       = 0xCAFE;
+
+

--- a/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/headers.p4
+++ b/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/headers.p4
@@ -1,6 +1,9 @@
 #ifndef _HEADERS_P4_
 #define _HEADERS_P4_
 
+#include <include/ethernet.p4>
+#include <include/ipv6.p4>
+
 struct headers {
     ethernet_t   ethernet;
     ipv6_t       ipv6;

--- a/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/headers.p4
+++ b/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/headers.p4
@@ -1,0 +1,9 @@
+#ifndef _HEADERS_P4_
+#define _HEADERS_P4_
+
+struct headers {
+    ethernet_t   ethernet;
+    ipv6_t       ipv6;
+}
+
+#endif // _HEADERS_P4_

--- a/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/ip-protocol.p4
+++ b/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/ip-protocol.p4
@@ -17,6 +17,9 @@
 // source here: 
 // https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml
 
+#ifndef _IP_PROTOCOL_P4_
+#define _IP_PROTOCOL_P4_
+
 const bit<8> IP_PROTOCOL_HOPOPT = 0;
 const bit<8> IP_PROTOCOL_ICMP = 1;
 const bit<8> IP_PROTOCOL_IGMP = 2;
@@ -156,3 +159,5 @@ const bit<8> IP_PROTOCOL_HIP  = 139;
 const bit<8> IP_PROTOCOL_SHIM6 = 140;
 const bit<8> IP_PROTOCOL_WESP = 141;
 const bit<8> IP_PROTOCOL_ROHC = 142;
+
+#endif // _IP_PROTOCOL_P4_

--- a/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/ip-protocol.p4
+++ b/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/ip-protocol.p4
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2019-present GÉANT RARE project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed On an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// source here: 
+// https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml
+
+const bit<8> IP_PROTOCOL_HOPOPT = 0;
+const bit<8> IP_PROTOCOL_ICMP = 1;
+const bit<8> IP_PROTOCOL_IGMP = 2;
+const bit<8> IP_PROTOCOL_GGP = 3;
+const bit<8> IP_PROTOCOL_IPV4 = 4;
+const bit<8> IP_PROTOCOL_ST = 5;
+const bit<8> IP_PROTOCOL_TCP = 6;
+const bit<8> IP_PROTOCOL_CBT = 7;
+const bit<8> IP_PROTOCOL_EGP = 8;
+const bit<8> IP_PROTOCOL_IGP = 9;
+const bit<8> IP_PROTOCOL_BBN_RCC_MON = 10;
+const bit<8> IP_PROTOCOL_NVP_II = 11;
+const bit<8> IP_PROTOCOL_PUP = 12;
+const bit<8> IP_PROTOCOL_ARGUS = 13;
+const bit<8> IP_PROTOCOL_EMCON = 14;
+const bit<8> IP_PROTOCOL_XNET = 15;
+const bit<8> IP_PROTOCOL_CHAOS = 16;
+const bit<8> IP_PROTOCOL_UDP = 17;
+const bit<8> IP_PROTOCOL_MUX = 18;
+const bit<8> IP_PROTOCOL_DCN_MEAS = 19;
+const bit<8> IP_PROTOCOL_HMP = 20;
+const bit<8> IP_PROTOCOL_PRM = 21;
+const bit<8> IP_PROTOCOL_XNS_IDP = 22;
+const bit<8> IP_PROTOCOL_TRUNK_1 = 23;
+const bit<8> IP_PROTOCOL_TRUNK_2 = 24;
+const bit<8> IP_PROTOCOL_LEAF_1 = 25;
+const bit<8> IP_PROTOCOL_LEAF_2 = 26;
+const bit<8> IP_PROTOCOL_RDP = 27;
+const bit<8> IP_PROTOCOL_IRTP = 28;
+const bit<8> IP_PROTOCOL_ISO_TP4 = 29;
+const bit<8> IP_PROTOCOL_NETBLT = 30;
+const bit<8> IP_PROTOCOL_MFE_NSP = 31;
+const bit<8> IP_PROTOCOL_MERIT_INP = 32;
+const bit<8> IP_PROTOCOL_DCCP = 33;
+const bit<8> IP_PROTOCOL_3PC = 34;
+const bit<8> IP_PROTOCOL_IDPR = 35;
+const bit<8> IP_PROTOCOL_XTP = 36;
+const bit<8> IP_PROTOCOL_DDP = 37;
+const bit<8> IP_PROTOCOL_IDPR_CMTP = 38;
+const bit<8> IP_PROTOCOL_TP = 39;
+const bit<8> IP_PROTOCOL_IL = 40;
+const bit<8> IP_PROTOCOL_IPV6 = 41;
+const bit<8> IP_PROTOCOL_SDRP = 42;
+const bit<8> IP_PROTOCOL_IPV6_ROUTE = 43;
+const bit<8> IP_PROTOCOL_IPV6_FRAG = 44;
+const bit<8> IP_PROTOCOL_IDRP = 45;
+const bit<8> IP_PROTOCOL_RSVP = 46;
+const bit<8> IP_PROTOCOL_GRE = 47;
+const bit<8> IP_PROTOCOL_DSR = 48;
+const bit<8> IP_PROTOCOL_BNA = 49;
+const bit<8> IP_PROTOCOL_ESP = 50;
+const bit<8> IP_PROTOCOL_AH = 51;
+const bit<8> IP_PROTOCOL_I_NLSP = 52;
+const bit<8> IP_PROTOCOL_SWIPE = 53;
+const bit<8> IP_PROTOCOL_NARP = 54;
+const bit<8> IP_PROTOCOL_MOBILE = 55;
+const bit<8> IP_PROTOCOL_TLSP = 56;
+const bit<8> IP_PROTOCOL_SKIP = 57;
+const bit<8> IP_PROTOCOL_IPV6_ICMP = 58;
+const bit<8> IP_PROTOCOL_IPV6_NONXT = 59;
+const bit<8> IP_PROTOCOL_IPV6_OPTS = 60;
+const bit<8> IP_PROTOCOL_CFTP = 62;
+const bit<8> IP_PROTOCOL_SAT_EXPAK = 64;
+const bit<8> IP_PROTOCOL_KRYPTOLAN = 65;
+const bit<8> IP_PROTOCOL_RVD = 66;
+const bit<8> IP_PROTOCOL_IPPC = 67;
+const bit<8> IP_PROTOCOL_SAT_MON = 69;
+const bit<8> IP_PROTOCOL_VISA = 70;
+const bit<8> IP_PROTOCOL_IPCV = 71;
+const bit<8> IP_PROTOCOL_CPNX = 72;
+const bit<8> IP_PROTOCOL_CPHB = 73;
+const bit<8> IP_PROTOCOL_WSN = 74;
+const bit<8> IP_PROTOCOL_PVP = 75;
+const bit<8> IP_PROTOCOL_BR_SAT_MON = 76;
+const bit<8> IP_PROTOCOL_SUN_ND = 77;
+const bit<8> IP_PROTOCOL_WB_MON = 78;
+const bit<8> IP_PROTOCOL_WB_EXPAK = 79;
+const bit<8> IP_PROTOCOL_ISO_IP = 80;
+const bit<8> IP_PROTOCOL_VMTP = 81;
+const bit<8> IP_PROTOCOL_SECURE_VMTP = 82;
+const bit<8> IP_PROTOCOL_VINES = 83;
+const bit<8> IP_PROTOCOL_TTP   = 84;
+const bit<8> IP_PROTOCOL_IPTM = 84;
+const bit<8> IP_PROTOCOL_NSFNET_IGP = 85;
+const bit<8> IP_PROTOCOL_DGP  = 86;
+const bit<8> IP_PROTOCOL_TCF = 87;
+const bit<8> IP_PROTOCOL_EIGRP = 88;
+const bit<8> IP_PROTOCOL_OSPFIGP = 89;
+const bit<8> IP_PROTOCOL_SPRITE_RPC = 90;
+const bit<8> IP_PROTOCOL_LARP = 91;
+const bit<8> IP_PROTOCOL_MTP = 92;
+const bit<8> IP_PROTOCOL_AX25 = 93;
+const bit<8> IP_PROTOCOL_IPIP = 94;
+const bit<8> IP_PROTOCOL_MICP = 95;
+const bit<8> IP_PROTOCOL_SCC_SP = 96;
+const bit<8> IP_PROTOCOL_ETHERIP = 97;
+const bit<8> IP_PROTOCOL_ENCAP = 98;
+const bit<8> IP_PROTOCOL_GMTP = 100;
+const bit<8> IP_PROTOCOL_IFMP = 101;
+const bit<8> IP_PROTOCOL_PNNI = 102;
+const bit<8> IP_PROTOCOL_PIM = 103;
+const bit<8> IP_PROTOCOL_ARIS = 104;
+const bit<8> IP_PROTOCOL_SCPS = 105;
+const bit<8> IP_PROTOCOL_QNX = 106;
+const bit<8> IP_PROTOCOL_A_N = 107;
+const bit<8> IP_PROTOCOL_IPCOMP = 108;
+const bit<8> IP_PROTOCOL_SNP = 109;
+const bit<8> IP_PROTOCOL_COMPAQ_PEER = 110;
+const bit<8> IP_PROTOCOL_IPX_IN_IP = 111;
+const bit<8> IP_PROTOCOL_VRRP = 112;
+const bit<8> IP_PROTOCOL_PGM = 113;
+const bit<8> IP_PROTOCOL_L2TP = 115;
+const bit<8> IP_PROTOCOL_DDX = 116;
+const bit<8> IP_PROTOCOL_IATP = 117;
+const bit<8> IP_PROTOCOL_STP = 118;
+const bit<8> IP_PROTOCOL_SRP = 119;
+const bit<8> IP_PROTOCOL_UTI = 120;
+const bit<8> IP_PROTOCOL_SMP = 121;
+const bit<8> IP_PROTOCOL_SM = 122;
+const bit<8> IP_PROTOCOL_PTP = 123;
+const bit<8> IP_PROTOCOL_ISISoIPV4 = 124;
+const bit<8> IP_PROTOCOL_FIRE = 125;
+const bit<8> IP_PROTOCOL_CRTP = 126;
+const bit<8> IP_PROTOCOL_CRUDP = 127;
+const bit<8> IP_PROTOCOL_SSCOPMCE = 128;
+const bit<8> IP_PROTOCOL_IPLT = 129;
+const bit<8> IP_PROTOCOL_SPS = 130;
+const bit<8> IP_PROTOCOL_PIPE = 131;
+const bit<8> IP_PROTOCOL_SCTP = 132;
+const bit<8> IP_PROTOCOL_FC   = 133;
+const bit<8> IP_PROTOCOL_RSVP_E2E_IGNORE = 134;
+const bit<8> IP_PROTOCOL_MOBILITY_HEADER = 135;
+const bit<8> IP_PROTOCOL_UDPLITE = 136;
+const bit<8> IP_PROTOCOL_MPLS_IN_IP = 137;
+const bit<8> IP_PROTOCOL_MANET = 138;
+const bit<8> IP_PROTOCOL_HIP  = 139;
+const bit<8> IP_PROTOCOL_SHIM6 = 140;
+const bit<8> IP_PROTOCOL_WESP = 141;
+const bit<8> IP_PROTOCOL_ROHC = 142;

--- a/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/ipv4.p4
+++ b/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/ipv4.p4
@@ -1,0 +1,22 @@
+/*
+ * IPv4 address encoded using 32 bits
+ */
+typedef bit<32> ipv4_addr_t;
+
+/*
+ * IPv4 header: as a header type, order matters
+ */
+header ipv4_t {
+   bit<4>    version;
+   bit<4>    ihl;
+   bit<8>    diffserv;
+   bit<16>   total_len;
+   bit<16>   identification;
+   bit<3>    flags;
+   bit<13>   frag_offset;
+   bit<8>    ttl;
+   bit<8>    protocol;
+   bit<16>   hdr_checksum;
+   ipv4_addr_t src_ipv4_addr;
+   ipv4_addr_t dst_ipv4_addr;
+}

--- a/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/ipv4.p4
+++ b/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/ipv4.p4
@@ -1,4 +1,3 @@
-
 #ifndef _IPV4_P4_
 #define _IPV4_P4_
 

--- a/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/ipv4.p4
+++ b/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/ipv4.p4
@@ -1,7 +1,8 @@
-/*
- * IPv4 address encoded using 32 bits
- */
-typedef bit<32> ipv4_addr_t;
+
+#ifndef _IPV4_P4_
+#define _IPV4_P4_
+
+#include <include/types.p4>
 
 /*
  * IPv4 header: as a header type, order matters
@@ -20,3 +21,5 @@ header ipv4_t {
    ipv4_addr_t src_ipv4_addr;
    ipv4_addr_t dst_ipv4_addr;
 }
+
+#endif // _IPV4_P4_

--- a/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/ipv6.p4
+++ b/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/ipv6.p4
@@ -1,0 +1,18 @@
+/*
+ * IPv6 address encoded using 128 bits
+ */
+typedef bit<128> ipv6_addr_t;
+
+/*
+ * IPv6 header: as a header type
+ */
+header ipv6_t {
+    bit<4> version;
+    bit<8> traffic_class;
+    bit<20> flow_label;
+    bit<16> payload_len;
+    bit<8> next_hdr;
+    bit<8> hop_limit;
+    ipv6_addr_t src_ipv6_addr;
+    ipv6_addr_t dst_ipv6_addr;
+}

--- a/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/ipv6.p4
+++ b/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/ipv6.p4
@@ -1,6 +1,6 @@
 
 #ifndef _IPV6_P4_
-#define_IPV6_P4_
+#define _IPV6_P4_
 
 #include <include/types.p4>
 

--- a/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/ipv6.p4
+++ b/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/ipv6.p4
@@ -1,7 +1,8 @@
-/*
- * IPv6 address encoded using 128 bits
- */
-typedef bit<128> ipv6_addr_t;
+
+#ifndef _IPV6_P4_
+#define_IPV6_P4_
+
+#include <include/types.p4>
 
 /*
  * IPv6 header: as a header type
@@ -16,3 +17,5 @@ header ipv6_t {
     ipv6_addr_t src_ipv6_addr;
     ipv6_addr_t dst_ipv6_addr;
 }
+
+#endif // _IPV6_P4_

--- a/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/l3_ipv6.p4
+++ b/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/l3_ipv6.p4
@@ -1,6 +1,10 @@
 #ifndef _L3_IPV6_P4_
 #define _L3_IPV6_P4_
 
+#include <v1model.p4>
+#include <include/p4-table.p4>
+#include <include/headers.p4>
+
 control ctl_l3_ipv6(inout headers hdr,
 inout standard_metadata_t standard_metadata) {
 

--- a/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/l3_ipv6.p4
+++ b/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/l3_ipv6.p4
@@ -1,0 +1,108 @@
+control ctl_l3_ipv6(inout headers hdr,
+inout standard_metadata_t standard_metadata) {
+
+    /* Discard via V1Model mark_to_drop(standard_metadata) */
+    action act_ipv6_fib_discard() {
+        mark_to_drop(standard_metadata);
+    }
+
+    /* Perform L3 forwarding. Conceptually, we need to distinguish the
+       cases when rewriting the Ethernet header is necessary and when
+       it is not.
+
+       If the destination is an address that belongs to the router
+       itself, a rewrite is not necessary, because the packet has
+       already reached its destination device.  The list of these
+       "local" addresses is stored in the exact-match table
+       tbl_ipv6_fib_host.
+
+       If the address belongs to a network that is directly attached
+       to the router, the packet can be sent to the final destination.
+
+       If the destination is not directly attached but there is a
+       prefix covering it in the routing table, the packet is
+       forwarded to the next-hop router.
+
+       In both of these cases, the router must rewrite the Ethernet
+       header with the proper source and destination MAC addresses.
+
+       The list of connected networks and routed prefixes is stored in
+       the lpm table tbl_ipv6_fib_lpm.  For a routed prefix, the table
+       stores the MAC addresses and egress port to reach the next-hop
+       router.  It is assumed that these parameters are obtained by
+       the control-plane when the FIB is programmed.
+
+       For a connected network, the router cannot generate the
+       destination MAC addresses for all possible destinations
+       beforehand. Instead, a match for a connected network would
+       trigger an address resolution request to the control-plane.
+
+       Once the control-plane has completed address resolution, it
+       adds a an entry to the exact-match table where the local
+       addresses are stored, but the entry for a connected destination
+       contains the same information as the lpm table. */
+
+    /* Packets for local addresses are sent to the CPU.  In the final
+       architecture, there will be a single designated port and this
+       function won't need an argument.  In the current lab setup,
+       each local port is connected via a separate port to the
+       control-plane. */
+    action act_ipv6_fib_local(egress_spec_t egress_cpu_port) {
+        standard_metadata.egress_spec = egress_cpu_port;
+    }
+
+    action act_ipv6_fib_forward(mac_addr_t src_mac_addr, mac_addr_t dst_mac_addr,
+    egress_spec_t egress_port) {
+        
+        /* Source is the MAC address of the egress port, destination
+           is the MAC address of the next-hop or the final destination
+           in case of a directly attached network. */
+        hdr.ethernet.src_mac_addr = src_mac_addr;
+        hdr.ethernet.dst_mac_addr = dst_mac_addr;
+        
+        /* Underflow causes no harm, because packets with a hop
+           limit of 0 have already been marked for drop */
+        hdr.ipv6.hop_limit = hdr.ipv6.hop_limit -1;
+        
+        standard_metadata.egress_spec = egress_port;
+    }
+
+    action act_ipv6_fib_glean() {
+        /* An address resolution request would be generate at this
+           point. For now, we have no choice but to drop the
+           packet. */
+        mark_to_drop(standard_metadata);
+    }
+    
+    table tbl_ipv6_fib_host {
+        key = {
+            hdr.ipv6.dst_ipv6_addr: exact;
+        }
+        actions = {
+            act_ipv6_fib_local;
+            act_ipv6_fib_forward;
+            NoAction;
+        }
+        size = IPV6_HOST_TABLE_SIZE;
+        const default_action = NoAction;
+    }
+    
+    table tbl_ipv6_fib_lpm {
+        key = {
+            hdr.ipv6.dst_ipv6_addr: lpm;
+        }
+        actions = {
+            act_ipv6_fib_forward;
+            act_ipv6_fib_glean;
+            act_ipv6_fib_discard;
+        }
+        size = IPV6_LPM_TABLE_SIZE;
+        const default_action = act_ipv6_fib_discard();
+    }
+
+    apply {
+        if (!tbl_ipv6_fib_host.apply().hit) {
+            tbl_ipv6_fib_lpm.apply();
+        }
+    }
+}          

--- a/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/l3_ipv6.p4
+++ b/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/l3_ipv6.p4
@@ -1,3 +1,6 @@
+#ifndef _L3_IPV6_P4_
+#define _L3_IPV6_P4_
+
 control ctl_l3_ipv6(inout headers hdr,
 inout standard_metadata_t standard_metadata) {
 
@@ -106,3 +109,5 @@ inout standard_metadata_t standard_metadata) {
         }
     }
 }          
+
+#endif // _L3_IPV6_P4_

--- a/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/p4-table.p4
+++ b/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/p4-table.p4
@@ -1,0 +1,119 @@
+/*
+Copyright 2013-present Barefoot Networks, Inc. 
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+#define MIN_SRAM_TABLE_SIZE                    1024
+#define MIN_TCAM_TABLE_SIZE                    512
+
+#define VALIDATE_PACKET_TABLE_SIZE             MIN_TCAM_TABLE_SIZE
+#define PORTMAP_TABLE_SIZE                     288
+#define STORM_CONTROL_TABLE_SIZE               MIN_TCAM_TABLE_SIZE
+#define STORM_CONTROL_METER_TABLE_SIZE         MIN_SRAM_TABLE_SIZE
+#define STORM_CONTROL_STATS_TABLE_SIZE         MIN_SRAM_TABLE_SIZE
+#define PORT_VLAN_TABLE_SIZE                   4096
+#define OUTER_ROUTER_MAC_TABLE_SIZE            MIN_SRAM_TABLE_SIZE
+#define DEST_TUNNEL_TABLE_SIZE                 MIN_SRAM_TABLE_SIZE
+#define IPV4_SRC_TUNNEL_TABLE_SIZE             MIN_SRAM_TABLE_SIZE
+#define IPV6_SRC_TUNNEL_TABLE_SIZE             MIN_SRAM_TABLE_SIZE
+#define TUNNEL_SRC_REWRITE_TABLE_SIZE          MIN_SRAM_TABLE_SIZE
+#define TUNNEL_DST_REWRITE_TABLE_SIZE          MIN_SRAM_TABLE_SIZE
+#define OUTER_MULTICAST_STAR_G_TABLE_SIZE      MIN_TCAM_TABLE_SIZE
+#define OUTER_MULTICAST_S_G_TABLE_SIZE         MIN_SRAM_TABLE_SIZE
+#define VNID_MAPPING_TABLE_SIZE                MIN_SRAM_TABLE_SIZE
+#define BD_TABLE_SIZE                          MIN_SRAM_TABLE_SIZE
+#define BD_FLOOD_TABLE_SIZE                    MIN_SRAM_TABLE_SIZE
+#define BD_STATS_TABLE_SIZE                    MIN_SRAM_TABLE_SIZE
+#define OUTER_MCAST_RPF_TABLE_SIZE             MIN_SRAM_TABLE_SIZE
+#define MPLS_TABLE_SIZE                        MIN_SRAM_TABLE_SIZE
+#define VALIDATE_MPLS_TABLE_SIZE               MIN_TCAM_TABLE_SIZE
+
+#define ROUTER_MAC_TABLE_SIZE                  MIN_SRAM_TABLE_SIZE
+#define MAC_TABLE_SIZE                         MIN_SRAM_TABLE_SIZE
+#define IPSG_TABLE_SIZE                        MIN_SRAM_TABLE_SIZE
+#define IPSG_PERMIT_SPECIAL_TABLE_SIZE         MIN_TCAM_TABLE_SIZE
+#define INGRESS_MAC_ACL_TABLE_SIZE             MIN_TCAM_TABLE_SIZE
+#define INGRESS_IP_ACL_TABLE_SIZE              MIN_TCAM_TABLE_SIZE
+#define INGRESS_IPV6_ACL_TABLE_SIZE            MIN_TCAM_TABLE_SIZE
+#define EGRESS_MAC_ACL_TABLE_SIZE              MIN_TCAM_TABLE_SIZE
+#define EGRESS_IP_ACL_TABLE_SIZE               MIN_TCAM_TABLE_SIZE
+#define EGRESS_IPV6_ACL_TABLE_SIZE             MIN_TCAM_TABLE_SIZE
+#define INGRESS_IP_RACL_TABLE_SIZE             MIN_TCAM_TABLE_SIZE
+#define INGRESS_IPV6_RACL_TABLE_SIZE           MIN_TCAM_TABLE_SIZE
+#define IP_NAT_TABLE_SIZE                      MIN_SRAM_TABLE_SIZE
+#define IP_NAT_FLOW_TABLE_SIZE                 MIN_TCAM_TABLE_SIZE
+#define EGRESS_NAT_TABLE_SIZE                  MIN_SRAM_TABLE_SIZE
+#define IPV4_LPM_TABLE_SIZE                    MIN_TCAM_TABLE_SIZE
+#define IPV6_LPM_TABLE_SIZE                    MIN_TCAM_TABLE_SIZE
+#define IPV4_HOST_TABLE_SIZE                   MIN_SRAM_TABLE_SIZE
+#define IPV6_HOST_TABLE_SIZE                   MIN_SRAM_TABLE_SIZE
+#define IPV4_MULTICAST_STAR_G_TABLE_SIZE       MIN_SRAM_TABLE_SIZE
+#define IPV4_MULTICAST_S_G_TABLE_SIZE          MIN_SRAM_TABLE_SIZE
+#define IPV6_MULTICAST_STAR_G_TABLE_SIZE       MIN_SRAM_TABLE_SIZE
+#define IPV6_MULTICAST_S_G_TABLE_SIZE          MIN_SRAM_TABLE_SIZE
+#define MCAST_RPF_TABLE_SIZE                   MIN_SRAM_TABLE_SIZE
+#define FWD_RESULT_TABLE_SIZE                  MIN_TCAM_TABLE_SIZE
+#define URPF_GROUP_TABLE_SIZE                  MIN_SRAM_TABLE_SIZE
+#define ECMP_GROUP_TABLE_SIZE                  MIN_SRAM_TABLE_SIZE
+#define ECMP_SELECT_TABLE_SIZE                 MIN_SRAM_TABLE_SIZE
+#define NEXTHOP_TABLE_SIZE                     MIN_SRAM_TABLE_SIZE
+#define LAG_GROUP_TABLE_SIZE                   MIN_SRAM_TABLE_SIZE
+#define LAG_SELECT_TABLE_SIZE                  MIN_SRAM_TABLE_SIZE
+#define SYSTEM_ACL_SIZE                        MIN_TCAM_TABLE_SIZE
+#define LEARN_NOTIFY_TABLE_SIZE                MIN_TCAM_TABLE_SIZE
+
+#define MAC_REWRITE_TABLE_SIZE                 MIN_TCAM_TABLE_SIZE
+#define EGRESS_VNID_MAPPING_TABLE_SIZE         MIN_SRAM_TABLE_SIZE
+#define EGRESS_BD_MAPPING_TABLE_SIZE           MIN_SRAM_TABLE_SIZE
+#define EGRESS_BD_STATS_TABLE_SIZE             MIN_SRAM_TABLE_SIZE
+#define REPLICA_TYPE_TABLE_SIZE                MIN_TCAM_TABLE_SIZE
+#define RID_TABLE_SIZE                         MIN_SRAM_TABLE_SIZE
+#define TUNNEL_DECAP_TABLE_SIZE                MIN_SRAM_TABLE_SIZE
+#define L3_MTU_TABLE_SIZE                      MIN_SRAM_TABLE_SIZE
+#define EGRESS_VLAN_XLATE_TABLE_SIZE           MIN_SRAM_TABLE_SIZE
+#define SPANNING_TREE_TABLE_SIZE               MIN_SRAM_TABLE_SIZE
+#define FABRIC_REWRITE_TABLE_SIZE              MIN_TCAM_TABLE_SIZE
+#define EGRESS_ACL_TABLE_SIZE                  MIN_TCAM_TABLE_SIZE
+#define INGRESS_ACL_RANGE_TABLE_SIZE           MIN_TCAM_TABLE_SIZE
+#define EGRESS_ACL_RANGE_TABLE_SIZE            MIN_TCAM_TABLE_SIZE
+#define VLAN_DECAP_TABLE_SIZE                  MIN_SRAM_TABLE_SIZE
+#define TUNNEL_HEADER_TABLE_SIZE               MIN_SRAM_TABLE_SIZE
+#define TUNNEL_REWRITE_TABLE_SIZE              MIN_SRAM_TABLE_SIZE
+#define TUNNEL_SMAC_REWRITE_TABLE_SIZE         MIN_SRAM_TABLE_SIZE
+#define TUNNEL_DMAC_REWRITE_TABLE_SIZE         MIN_SRAM_TABLE_SIZE
+#define MIRROR_SESSIONS_TABLE_SIZE             MIN_SRAM_TABLE_SIZE
+#define MIRROR_COALESCING_SESSIONS_TABLE_SIZE  MIN_SRAM_TABLE_SIZE
+#define DROP_STATS_TABLE_SIZE                  MIN_SRAM_TABLE_SIZE
+#define ACL_STATS_TABLE_SIZE                   MIN_SRAM_TABLE_SIZE
+#define METER_INDEX_TABLE_SIZE                 MIN_SRAM_TABLE_SIZE
+#define METER_ACTION_TABLE_SIZE                MIN_SRAM_TABLE_SIZE
+
+#define INT_TERMINATE_TABLE_SIZE               256
+#define INT_SOURCE_TABLE_SIZE                  256
+#define INT_UNDERLAY_ENCAP_TABLE_SIZE          8
+
+#define SFLOW_INGRESS_TABLE_SIZE               512
+#define SFLOW_EGRESS_TABLE_SIZE                512
+#define MAX_SFLOW_SESSIONS                     16
+
+#define INGRESS_QOS_MAP_TABLE_SIZE             512
+#define EGRESS_QOS_MAP_TABLE_SIZE              512
+#define QUEUE_TABLE_SIZE                       512
+#define DSCP_TO_TC_AND_COLOR_TABLE_SIZE        64
+#define PCP_TO_TC_AND_COLOR_TABLE_SIZE         64
+
+#define COPP_TABLE_SIZE                        128
+
+#define EGRESS_PORT_LKP_FIELD_SIZE             4

--- a/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/p4-table.p4
+++ b/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/p4-table.p4
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#ifndef _P4_TABLE_P4_
+#define _P4_TABLE_P4_
 
 #define MIN_SRAM_TABLE_SIZE                    1024
 #define MIN_TCAM_TABLE_SIZE                    512
@@ -117,3 +119,5 @@ limitations under the License.
 #define COPP_TABLE_SIZE                        128
 
 #define EGRESS_PORT_LKP_FIELD_SIZE             4
+
+#endif // _P4_TABLE_P4_

--- a/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/types.p4
+++ b/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/types.p4
@@ -1,0 +1,24 @@
+#ifndef _TYPES_P4_
+#define _TYPES_P4_
+
+/*
+* egress_spec port encoded using 9 bits
+*/ 
+typedef bit<9>  egress_spec_t;
+
+/*
+ * HW MAC address encoded using 48 bits
+ */
+typedef bit<48> mac_addr_t;
+
+/*
+ * IPv4 address encoded using 32 bits
+ */
+typedef bit<32> ipv4_addr_t;
+
+/*
+ * IPv6 address encoded using 128 bits
+ */
+typedef bit<128> ipv6_addr_t;
+
+#endif // _TYPES_P4_

--- a/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/validate_ipv6.p4
+++ b/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/validate_ipv6.p4
@@ -1,5 +1,10 @@
 /* Validate an IPv6 packet, currently only the hop_limit.  Maybe also
-   check for multicast in the source address, for example */
+check for multicast in the source address, for example */
+
+#ifndef _VALIDATE_IPV6_P4_
+#define _VALIDATE_IPV6_P4_
+
+#include <include/headers.p4>
 
 control ctl_validate_ipv6(inout headers hdr,
 inout standard_metadata_t standard_metadata) {
@@ -25,3 +30,5 @@ inout standard_metadata_t standard_metadata) {
         tbl_validate_ipv6.apply();
     }
 }
+
+#endif // _VALIDATE_IPV6_P4_

--- a/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/validate_ipv6.p4
+++ b/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/validate_ipv6.p4
@@ -4,6 +4,7 @@ check for multicast in the source address, for example */
 #ifndef _VALIDATE_IPV6_P4_
 #define _VALIDATE_IPV6_P4_
 
+#include <v1model.p4>
 #include <include/headers.p4>
 
 control ctl_validate_ipv6(inout headers hdr,

--- a/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/validate_ipv6.p4
+++ b/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/include/validate_ipv6.p4
@@ -1,0 +1,27 @@
+/* Validate an IPv6 packet, currently only the hop_limit.  Maybe also
+   check for multicast in the source address, for example */
+
+control ctl_validate_ipv6(inout headers hdr,
+inout standard_metadata_t standard_metadata) {
+    action malformed() {
+        mark_to_drop(standard_metadata);
+    }
+    
+    table tbl_validate_ipv6 {
+        key = {
+            hdr.ipv6.hop_limit: exact;
+        }
+        actions = {
+            malformed;
+            NoAction;
+        }
+        const default_action = NoAction;
+        const entries = {
+            ( 0 ) : malformed();
+        }
+    }
+    
+    apply {
+        tbl_validate_ipv6.apply();
+    }
+}

--- a/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/tables.in
+++ b/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/tables.in
@@ -1,13 +1,26 @@
+# S    fd00::1/128         1/0     ethernet0  fd00:0:0:1::1  01:11:28
 table_add ctl_ingress.l3.tbl_ipv6_fib_lpm ctl_ingress.l3.act_ipv6_fib_forward fd00::1/128 => 00:00:0a:00:01:fe 00:00:0a:00:01:01 1
+# S    fd00::2/128         1/0     ethernet1  fd00:0:0:2::2  01:11:28
 table_add ctl_ingress.l3.tbl_ipv6_fib_lpm ctl_ingress.l3.act_ipv6_fib_forward fd00::2/128 => 00:00:0a:00:02:fe 00:00:0a:00:02:02 2
+# C    fd00::fe/128        0/0     loopback0  null           01:11:28
 table_add ctl_ingress.l3.tbl_ipv6_fib_host ctl_ingress.l3.act_ipv6_fib_local fd00::fe => 255
+# C    fd00:0:0:1::/64     0/0     ethernet0  null           01:11:28
 table_add ctl_ingress.l3.tbl_ipv6_fib_lpm ctl_ingress.l3.act_ipv6_fib_glean fd00:0:0:1::/64
+# LOC  fd00:0:0:1::fe/128  0/1     ethernet0  null           01:11:28
 table_add ctl_ingress.l3.tbl_ipv6_fib_host ctl_ingress.l3.act_ipv6_fib_local fd00:0:0:1::fe => 255
+# C    fd00:0:0:2::/64     0/0     ethernet1  null           01:11:28
 table_add ctl_ingress.l3.tbl_ipv6_fib_lpm ctl_ingress.l3.act_ipv6_fib_glean fd00:0:0:2::/64 =>
+# LOC  fd00:0:0:2::fe/128  0/1     ethernet1  null           01:11:28
 table_add ctl_ingress.l3.tbl_ipv6_fib_host ctl_ingress.l3.act_ipv6_fib_local fd00:0:0:2::fe => 254
+# S    fd00:0:1:1::/64     1/0     ethernet0  fd00:0:0:1::1  01:11:28
 table_add ctl_ingress.l3.tbl_ipv6_fib_lpm ctl_ingress.l3.act_ipv6_fib_forward fd00:0:1:1::/64 => 00:00:0a:00:01:fe 00:00:0a:00:01:01 1
+# S    fd00:0:2:2::/64     1/0     ethernet1  fd00:0:0:2::2  01:11:28
 table_add ctl_ingress.l3.tbl_ipv6_fib_lpm ctl_ingress.l3.act_ipv6_fib_forward fd00:0:2:2::/64 => 00:00:0a:00:02:fe 00:00:0a:00:02:02 2
+# C    fd00:0:6:6::/64     0/0     loopback1  null           01:11:28
 table_add ctl_ingress.l3.tbl_ipv6_fib_lpm ctl_ingress.l3.act_ipv6_fib_glean fd00:0:6:6::/64  =>
+# LOC  fd00:0:6:6::6/128   0/1     loopback1  null           01:11:28
 table_add ctl_ingress.l3.tbl_ipv6_fib_host ctl_ingress.l3.act_ipv6_fib_local fd00:0:6:6::6 => 255
+# Neighbor entry for fd00:0:0:1::1
 table_add ctl_ingress.l3.tbl_ipv6_fib_host ctl_ingress.l3.act_ipv6_fib_forward fd00:0:0:1::1 => 00:00:0a:00:01:fe 00:00:0a:00:01:01 1
+# Neighbor entry for fd00:0:0:2::2
 table_add ctl_ingress.l3.tbl_ipv6_fib_host ctl_ingress.l3.act_ipv6_fib_forward fd00:0:0:2::2 => 00:00:0a:00:02:fe 00:00:0a:00:02:02 2

--- a/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/tables.in
+++ b/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/tables.in
@@ -1,0 +1,13 @@
+table_add ctl_ingress.l3.tbl_ipv6_fib_lpm ctl_ingress.l3.act_ipv6_fib_forward fd00::1/128 => 00:00:0a:00:01:fe 00:00:0a:00:01:01 1
+table_add ctl_ingress.l3.tbl_ipv6_fib_lpm ctl_ingress.l3.act_ipv6_fib_forward fd00::2/128 => 00:00:0a:00:02:fe 00:00:0a:00:02:02 2
+table_add ctl_ingress.l3.tbl_ipv6_fib_host ctl_ingress.l3.act_ipv6_fib_local fd00::fe => 255
+table_add ctl_ingress.l3.tbl_ipv6_fib_lpm ctl_ingress.l3.act_ipv6_fib_glean fd00:0:0:1::/64
+table_add ctl_ingress.l3.tbl_ipv6_fib_host ctl_ingress.l3.act_ipv6_fib_local fd00:0:0:1::fe => 255
+table_add ctl_ingress.l3.tbl_ipv6_fib_lpm ctl_ingress.l3.act_ipv6_fib_glean fd00:0:0:2::/64 =>
+table_add ctl_ingress.l3.tbl_ipv6_fib_host ctl_ingress.l3.act_ipv6_fib_local fd00:0:0:2::fe => 254
+table_add ctl_ingress.l3.tbl_ipv6_fib_lpm ctl_ingress.l3.act_ipv6_fib_forward fd00:0:1:1::/64 => 00:00:0a:00:01:fe 00:00:0a:00:01:01 1
+table_add ctl_ingress.l3.tbl_ipv6_fib_lpm ctl_ingress.l3.act_ipv6_fib_forward fd00:0:2:2::/64 => 00:00:0a:00:02:fe 00:00:0a:00:02:02 2
+table_add ctl_ingress.l3.tbl_ipv6_fib_lpm ctl_ingress.l3.act_ipv6_fib_glean fd00:0:6:6::/64  =>
+table_add ctl_ingress.l3.tbl_ipv6_fib_host ctl_ingress.l3.act_ipv6_fib_local fd00:0:6:6::6 => 255
+table_add ctl_ingress.l3.tbl_ipv6_fib_host ctl_ingress.l3.act_ipv6_fib_forward fd00:0:0:1::1 => 00:00:0a:00:01:fe 00:00:0a:00:01:01 1
+table_add ctl_ingress.l3.tbl_ipv6_fib_host ctl_ingress.l3.act_ipv6_fib_forward fd00:0:0:2::2 => 00:00:0a:00:02:fe 00:00:0a:00:02:02 2

--- a/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/unoptimized-ipv6-forwarding.p4
+++ b/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/unoptimized-ipv6-forwarding.p4
@@ -94,13 +94,8 @@ control ctl_compute_checksum(inout headers hdr, inout metadata meta) {
 */
 control ctl_deprs(packet_out packet, in headers hdr) {
     apply {
-        /* parsed headers that have been modified
-        * in ctl_ingress and ctl_ingress
-        * have to be added again into the packet.
-        * for emission in the wire
-        */
-        packet.emit(hdr.ethernet);
-        packet.emit(hdr.ipv6);
+        /* Emit all valid headers */
+        packet.emit(hdr);
 
     }
 }

--- a/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/unoptimized-ipv6-forwarding.p4
+++ b/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/unoptimized-ipv6-forwarding.p4
@@ -2,68 +2,24 @@
 * P4 language version: P4_16 
 */
 
-/*
-* include P4 core library 
-*/
 #include <core.p4>
-
-/* 
-* include P4 v1model library implemented by simple_switch 
-*/
 #include <v1model.p4>
-
-/*
-* include Ethertype mapping 
-*/
 #include <include/ethertype.p4>
-
-/* 
-* include IP protocol mapping 
-*/
 #include <include/ip-protocol.p4>
-
-/* 
-* include Ethernet types and protocol headers
-*/
 #include <include/ethernet.p4>
-
-/* 
-* include IPv4 types and protocol headers
-*/
 #include <include/ipv4.p4>
-
-/* 
-* include IPv6 types and protocol headers
-*/
 #include <include/ipv6.p4>
-
-/* 
-* include P4 table size declaration 
-*/
 #include <include/p4-table.p4>
+#include <include/types.p4>
+#include <include/headers.p4>
+#include <include/validate_ipv6.p4>
+#include <include/l3_ipv6.p4>
 
 /*
-* egress_spec port encoded using 9 bits
-*/ 
-typedef bit<9>  egress_spec_t;
-
-/*
-* empty struct but still need to be declared as it is used in parser
+* User-defined metadata
 */
 struct metadata {
 }
-
-/*
-* Our P4 program header structure 
-*/
-struct headers {
-    ethernet_t   ethernet;
-    ipv6_t       ipv6;
-}
-
-/* Must come after declarations above */
-#include <include/validate_ipv6.p4>
-#include <include/l3_ipv6.p4>
 
 /*
 * V1Model PARSER

--- a/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/unoptimized-ipv6-forwarding.p4
+++ b/00-unit-labs/0008-unoptimized-ipv6-forwarding/p4src/unoptimized-ipv6-forwarding.p4
@@ -1,0 +1,162 @@
+/*
+* P4 language version: P4_16 
+*/
+
+/*
+* include P4 core library 
+*/
+#include <core.p4>
+
+/* 
+* include P4 v1model library implemented by simple_switch 
+*/
+#include <v1model.p4>
+
+/*
+* include Ethertype mapping 
+*/
+#include <include/ethertype.p4>
+
+/* 
+* include IP protocol mapping 
+*/
+#include <include/ip-protocol.p4>
+
+/* 
+* include Ethernet types and protocol headers
+*/
+#include <include/ethernet.p4>
+
+/* 
+* include IPv4 types and protocol headers
+*/
+#include <include/ipv4.p4>
+
+/* 
+* include IPv6 types and protocol headers
+*/
+#include <include/ipv6.p4>
+
+/* 
+* include P4 table size declaration 
+*/
+#include <include/p4-table.p4>
+
+/*
+* egress_spec port encoded using 9 bits
+*/ 
+typedef bit<9>  egress_spec_t;
+
+/*
+* empty struct but still need to be declared as it is used in parser
+*/
+struct metadata {
+}
+
+/*
+* Our P4 program header structure 
+*/
+struct headers {
+    ethernet_t   ethernet;
+    ipv6_t       ipv6;
+}
+
+/* Must come after declarations above */
+#include <include/validate_ipv6.p4>
+#include <include/l3_ipv6.p4>
+
+/*
+* V1Model PARSER
+*/
+parser prs_main(packet_in packet,
+out headers hdr,
+inout metadata meta,
+inout standard_metadata_t standard_metadata) {
+
+    state start {
+        packet.extract(hdr.ethernet);
+        transition select(hdr.ethernet.ethertype) {
+            ETHERTYPE_IPV6: prs_ipv6;
+            // Default rejects all other ethertypes
+        }
+    }
+
+    state prs_ipv6 {
+        packet.extract(hdr.ipv6);
+        transition accept;
+    }
+
+}
+
+/*
+* V1Model CHECKSUM VERIFICATION 
+*/
+control ctl_verify_checksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+/*
+* V1Model INGRESS
+*/
+control ctl_ingress(inout headers hdr,
+inout metadata meta,
+inout standard_metadata_t standard_metadata) {
+
+    ctl_validate_ipv6() validate;
+    ctl_l3_ipv6() l3;
+
+    apply {
+        if (hdr.ipv6.isValid()) {
+            validate.apply(hdr, standard_metadata);
+            l3.apply(hdr, standard_metadata);
+        }
+    }
+}
+
+/*
+* V1Model EGRESS
+*/
+
+control ctl_egress(inout headers hdr,
+inout metadata meta,
+inout standard_metadata_t standard_metadata) {
+    apply {
+    }
+}
+
+/*
+* V1Model CHECKSUM COMPUTATION
+*/
+control ctl_compute_checksum(inout headers hdr, inout metadata meta) {
+    apply {
+    }
+}
+
+/*
+* V1Model DEPARSER
+*/
+control ctl_deprs(packet_out packet, in headers hdr) {
+    apply {
+        /* parsed headers that have been modified
+        * in ctl_ingress and ctl_ingress
+        * have to be added again into the packet.
+        * for emission in the wire
+        */
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv6);
+
+    }
+}
+
+/*
+* V1Model P4 Switch define in v1model.p4
+*/
+V1Switch(
+prs_main(),
+ctl_verify_checksum(),
+ctl_ingress(),
+ctl_egress(),
+ctl_compute_checksum(),
+ctl_deprs()
+) main;


### PR DESCRIPTION
I have tried to modularize the code a bit more by defining separate controls for packet validation and L3 forwarding. The forwarding code is a bit different from the IPv4 lab to cover all cases (also, I think that the Ethernet rewriting rule in the IPv4 lab is not quite correct).

My goal was to be able to easily transform the output of a `show ipv6 route` on `core1` to table programming rules.

I've also added the address and static routing configuration needed by the lab to the topology since it will be used by multiple labs.